### PR TITLE
[INFRA] Set up default rulesets for default and release branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,8 +18,8 @@
 # see https://s.apache.org/asfyaml for more information
 
 notifications:
-  commits:      commits@allura.apache.org
-  issues:       dev@allura.apache.org
+  commits: commits@allura.apache.org
+  issues: dev@allura.apache.org
   pullrequests: dev@allura.apache.org
 github:
   description: "Apache Allura - a software forge to manage source code repositories, bug reports, discussions, wiki pages, blogs, and more"
@@ -39,5 +39,18 @@ github:
     wiki: false
     issues: false
     projects: false
-  dependabot_alerts:  true
+  dependabot_alerts: true
   dependabot_updates: false
+  rulesets:
+    - name: "Default Branch Protection"
+      type: branch
+      branches:
+        includes:
+          - "~DEFAULT_BRANCH"
+          - "release/*"
+          - "rel/*"
+        excludes: []
+      bypass_teams:
+        - root
+      restrict_deletion: true
+      restrict_force_push: true


### PR DESCRIPTION
This Pull Request enables the repository to conform with the "sane default security settings" of the Apache Software Foundation by configuring a default branch ruleset that protects the default branch and any release branches.

Note that `~DEFAULT_BRANCH` is a GitHub symbolic link to the current default branch (HEAD) of the repository and does not need changing.
If the managing project does not wish to set up these defaults, please close this Pull Request. Alternatively, the project may merge this Pull Request to apply the changes immediately.

If no action is taken, this Pull Request will be automatically merged by the Apache Infrastructure team on **2026-06-14** (30 days from now).

For any further information, please reach us on Slack or at: users@infra.apache.org
